### PR TITLE
Webpack and inline-imports

### DIFF
--- a/pack-node.sh
+++ b/pack-node.sh
@@ -6,8 +6,9 @@ const fs = require('fs');
 const buffer = fs.readFileSync('./pkg/schnorrkel_js_bg.wasm');
 
 fs.writeFileSync('./pkg/schnorrkel_js_bg.js', `
+const schnorrkel_js = require('./schnorrkel_js');
 const imports = {};
-imports['./schnorrkel_js'] = require('./schnorrkel_js');
+imports['./schnorrkel_js'] = schnorrkel_js;
 const bytes = Buffer.from('${buffer.toString('base64')}', 'base64');
 const wasmModule = new WebAssembly.Module(bytes);
 const wasmInstance = new WebAssembly.Instance(wasmModule, imports);


### PR DESCRIPTION
Webpack produces a (harmless) warning with the original form - this just cleans that up with an explicit require