### PR TITLE
chore: replace @parity with @substrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Provides a Javascript wrapper for some of the high-level functionality provided 
 ### Install 
 
 ```
-npm install @parity/schnorrkel-js
+npm install @substrate/schnorrkel-js
 ```
 
 ### API 

--- a/pre-publish.sh
+++ b/pre-publish.sh
@@ -4,7 +4,7 @@
 wasm-pack build --target nodejs
 
 # Fix the name 
-sed -i -e 's/schnorrkel-js/@parity\/schnorrkel-js/g' pkg/package.json
+sed -i -e 's/schnorrkel-js/@substrate\/schnorrkel-js/g' pkg/package.json
 
 # Run the script to fix node/browser import support
 ./pack-node.sh

--- a/pre-publish.sh
+++ b/pre-publish.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 
 # Compile the latest version; update ./pkg and readme files in it.
-wasm-pack build --target nodejs
-
-# Fix the name 
-sed -i -e 's/schnorrkel-js/@substrate\/schnorrkel-js/g' pkg/package.json
+wasm-pack build --target nodejs --scope substrate
 
 # Run the script to fix node/browser import support
 ./pack-node.sh


### PR DESCRIPTION
For clarity for future JS devs, let's put all Ethereum packages under `@parity/*`, and Substrate ones under `@substrate`