### PR TITLE
Derivation functions (hard/soft for pair, soft for public)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schnorrkel-js"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["kianenigma <Kian.peymani@gmail.com>"]
 edition = "2018"
 
@@ -10,8 +10,8 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-test = { version = "0.2" }
-sha2 = { version = "0.8"}
-schnorrkel = { version = "0.0", features = ["nightly"]}
+schnorrkel = { version = "0.1", features = ["nightly"]}
 
 [dev-dependencies]
+hex-literal = "0.1.4"
 rand = { version = "0.6.5", features = ["wasm-bindgen"] }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,9 +1,8 @@
 
 use schnorrkel::keys::*;
-use schnorrkel::context::{signing_context}; 
+use schnorrkel::context::{signing_context};
+use schnorrkel::derive::{Derivation, ChainCode, CHAIN_CODE_LENGTH};
 use schnorrkel::sign::{Signature,SIGNATURE_LENGTH};
-
-use sha2::Sha512;
 
 // We must make sure that this is the same as declared in the substrate source code.
 const SIGNING_CTX: &'static [u8] = b"substrate";
@@ -12,7 +11,46 @@ const SIGNING_CTX: &'static [u8] = b"substrate";
 fn keypair_from_seed(seed: &[u8]) -> Keypair {
 	let mini_key: MiniSecretKey = MiniSecretKey::from_bytes(seed)
 		.expect("32 bytes can always build a key; qed");
-	mini_key.expand_to_keypair::<Sha512>()
+	mini_key.expand_to_keypair()
+}
+
+/// ChainCode construction helper
+fn create_cc(data: &[u8]) -> ChainCode {
+	let mut cc = [0u8; CHAIN_CODE_LENGTH];
+
+	cc.copy_from_slice(&data);
+
+	ChainCode(cc)
+}
+
+pub fn __derive_keypair_hard(pair: &[u8], cc: &[u8]) -> [u8; KEYPAIR_LENGTH] {
+	let derived = match Keypair::from_bytes(pair) {
+		Ok(kp) => kp.hard_derive_mini_secret_key(Some(create_cc(cc)), &[]).0.expand_to_keypair(),
+		Err(_) => panic!("Provided pair is invalid.")
+	};
+	let mut kp = [0u8; KEYPAIR_LENGTH];
+	kp.copy_from_slice(&derived.to_bytes());
+	kp
+}
+
+pub fn __derive_keypair_soft(pair: &[u8], cc: &[u8]) -> [u8; KEYPAIR_LENGTH] {
+	let derived = match Keypair::from_bytes(pair) {
+		Ok(kp) => kp.derived_key_simple(create_cc(cc), &[]).0,
+		Err(_) => panic!("Provided pair is invalid.")
+	};
+	let mut kp = [0u8; KEYPAIR_LENGTH];
+	kp.copy_from_slice(&derived.to_bytes());
+	kp
+}
+
+pub fn __derive_public_soft(public: &[u8], cc: &[u8]) -> [u8; PUBLIC_KEY_LENGTH] {
+	let derived = match PublicKey::from_bytes(public) {
+		Ok(pk) => pk.derived_key_simple(create_cc(cc), &[]).0,
+		Err(_) => panic!("Provided publickey is invalid.")
+	};
+	let mut pk = [0u8; PUBLIC_KEY_LENGTH];
+	pk.copy_from_slice(&derived.to_bytes());
+	pk
 }
 
 pub fn __keypair_from_seed(seed: &[u8]) -> [u8; KEYPAIR_LENGTH] {
@@ -21,7 +59,6 @@ pub fn __keypair_from_seed(seed: &[u8]) -> [u8; KEYPAIR_LENGTH] {
 	kp.copy_from_slice(&keypair);
 	kp
 }
-
 
 pub fn __secret_from_seed(seed: &[u8]) -> [u8; SECRET_KEY_LENGTH] {
 	let secret = keypair_from_seed(seed).secret.to_bytes();
@@ -53,7 +90,7 @@ pub fn __sign(public: &[u8], private: &[u8], message: &[u8]) -> [u8; SIGNATURE_L
 		Ok(some_public) => some_public,
 		Err(_) => panic!("Provided public key is invalid.")
 	};
-	
+
 	let context = signing_context(SIGNING_CTX);
 	secret.sign(context.bytes(message), &public).to_bytes()
 }


### PR DESCRIPTION
Tested via `cargo test` by swapping the `#[wasm_bindgen_test]` to `#[test]` for `hard_derives_pair`, `soft_derives_pair` & `soft_derives_public`, there are no WASM-specific tests included here.

This basically is the code from https://github.com/polkadot-js/wasm/blob/master/packages/wasm-schnorrkel/src/lib.rs#L64-L104 adjusted fitting in with the conventions used here

Addresses https://github.com/paritytech/schnorrkel-js/issues/9

With the above macro swap, this is my outputs -

```
 $ cargo test
   Compiling schnorrkel-js v0.2.0 (/Users/jacogreeff/Projects/paritytech/schnorrkel-js)
    Finished dev [unoptimized + debuginfo] target(s) in 4.52s
     Running target/debug/deps/schnorrkel_js-13f16448e9949324

running 3 tests
test tests::hard_derives_pair ... ok
test tests::soft_derives_pair ... ok
test tests::soft_derives_public ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

(As mentioned, no JS WASM tests here)