### PR TITLE
Add sign & verify methods w/ signing context param.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-test = { version = "0.2" }
-schnorrkel = { version = "0.1", features = ["nightly"]}
+schnorrkel = { version = "0.6.1", features = ["nightly"]}
 
 [dev-dependencies]
 hex-literal = "0.1.4"


### PR DESCRIPTION
Related to https://github.com/paritytech/schnorrkel-js/issues/12

Introduces signing context interfaces for sign and verify while maintaining back compatibility. Might be an interface to consolidate in a later version.

The upgrade of schnorrkel 0.1 to 0.6 seems to have broken the derives tests. Need guidance on how to proceed.